### PR TITLE
Remove utf-8 from Content-Type as it us redundant

### DIFF
--- a/jsend.go
+++ b/jsend.go
@@ -81,7 +81,7 @@ func Success(w http.ResponseWriter, data interface{}, statuses ...int) error {
 //
 // If necessary, the status code can be specified through the third parameter.
 func Write(w http.ResponseWriter, body Body, statuses ...int) error {
-	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.Header().Set("Content-Type", "application/json")
 
 	if len(statuses) > 0 {
 		w.WriteHeader(statuses[0])

--- a/jsend_test.go
+++ b/jsend_test.go
@@ -43,7 +43,7 @@ func TestWrite(t *testing.T) {
 		},
 	}
 
-	contentType := "application/json; charset=utf-8"
+	contentType := "application/json"
 	for _, test := range tests {
 		response := httptest.NewRecorder()
 		var err error


### PR DESCRIPTION
See: https://stackoverflow.com/questions/9254891/what-does-content-type-application-json-charset-utf-8-really-mean

utf-8 is the only allowed charset for application/json and therefore the default.